### PR TITLE
Fixing DH PSF Calibration

### DIFF
--- a/double_helix/DoubleGaussFit.py
+++ b/double_helix/DoubleGaussFit.py
@@ -273,14 +273,14 @@ class Detector(object):
         # convert input image to float
         image=image.astype('float32')
         # print('here - image size: %s, g2a size: %s' % (image.shape, self.g2a.shape))
-        g2a_xy = ndimage.convolve(image, self.g2a)
-        g2b_xy = ndimage.convolve(image, self.g2b)
-        g2c_xy = ndimage.convolve(image, self.g2c)
+        g2a_xy = ndimage.convolve(image, self.g2a, mode='nearest')
+        g2b_xy = ndimage.convolve(image, self.g2b, mode='nearest')
+        g2c_xy = ndimage.convolve(image, self.g2c, mode='nearest')
 
-        h2a_xy = ndimage.convolve(image, self.h2a)
-        h2b_xy = ndimage.convolve(image, self.h2b)
-        h2c_xy = ndimage.convolve(image, self.h2c)
-        h2d_xy = ndimage.convolve(image, self.h2d)
+        h2a_xy = ndimage.convolve(image, self.h2a, mode='nearest')
+        h2b_xy = ndimage.convolve(image, self.h2b, mode='nearest')
+        h2c_xy = ndimage.convolve(image, self.h2c, mode='nearest')
+        h2d_xy = ndimage.convolve(image, self.h2d, mode='nearest')
 
         c_2= 0.5 * (g2a_xy**2 - g2c_xy**2) \
                     + 0.46875*(h2a_xy**2 - h2d_xy**2) \
@@ -493,7 +493,7 @@ class DumbellFitFactory(FFBase.FitFactory):
         return results
 
     def FromPoint(self, x, y, z=None, roiHalfSize=7, axialHalfSize=0):
-        roiHalfSize = self.metadata.getOrDefault('Analysis.ROISize', roiHalfSize)
+    
         X, Y, data, background, sigma, xslice, yslice, zslice = self.getROIAtPoint(x, y, z, roiHalfSize, axialHalfSize)
 
         dataMean = data - background

--- a/double_helix/detection_params_dialog.py
+++ b/double_helix/detection_params_dialog.py
@@ -1,0 +1,57 @@
+import wx
+
+class DetectionParamsDialog(wx.Dialog):
+    def __init__(self, parent, defaultVal=-1e3):
+        wx.Dialog.__init__(self, parent)
+
+        main_sizer = wx.BoxSizer(wx.VERTICAL)
+
+        # Title
+        title = wx.StaticText(self, -1, "Enter DH PSF Detection Parameters")
+        font = title.GetFont()
+        font.SetPointSize(12)
+        font.SetWeight(wx.FONTWEIGHT_BOLD)
+        title.SetFont(font)
+        main_sizer.Add(title, 0, wx.ALIGN_CENTER | wx.ALL, 10)
+
+        # ROI Half Size
+        row1 = wx.BoxSizer(wx.HORIZONTAL)
+        row1.Add(wx.StaticText(self, -1, u'ROI Half Size [px]:'), 0, wx.ALIGN_CENTER_VERTICAL | wx.ALL, 5)
+        self.roiHalfSize = wx.TextCtrl(self, -1, '%1.6G' % defaultVal, size=(80, -1))
+        row1.Add(self.roiHalfSize, 0, wx.ALIGN_CENTER_VERTICAL | wx.ALL, 5)
+        main_sizer.Add(row1, 0, wx.EXPAND | wx.ALL, 0)
+
+        # Detection Filter Sigma
+        row2 = wx.BoxSizer(wx.HORIZONTAL)
+        row2.Add(wx.StaticText(self, -1, u'Detection Filter Sigma [px]:'), 0, wx.ALIGN_CENTER_VERTICAL | wx.ALL, 5)
+        self.detectionFilterSigma = wx.TextCtrl(self, -1,'%1.6G' % defaultVal, size=(80, -1))
+        row2.Add(self.detectionFilterSigma, 0, wx.ALIGN_CENTER_VERTICAL | wx.ALL, 5)
+        main_sizer.Add(row2, 0, wx.EXPAND | wx.ALL, 0)
+
+        # Initial Lobe Sep. Guess
+        row3 = wx.BoxSizer(wx.HORIZONTAL)
+        row3.Add(wx.StaticText(self, -1, u'Initial Lobe Sep. Guess [nm]:'), 0, wx.ALIGN_CENTER_VERTICAL | wx.ALL, 5)
+        self.initLobeSepGuess = wx.TextCtrl(self, -1, '%1.6G' % defaultVal, size=(80, -1))
+        row3.Add(self.initLobeSepGuess, 0, wx.ALIGN_CENTER_VERTICAL | wx.ALL, 5)
+        main_sizer.Add(row3, 0, wx.EXPAND | wx.ALL, 0)
+
+        # Initial Lobe Sigma Guess
+        row4 = wx.BoxSizer(wx.HORIZONTAL)
+        row4.Add(wx.StaticText(self, -1, u'Initial Lobe Sigma Guess [nm]:'), 0, wx.ALIGN_CENTER_VERTICAL | wx.ALL, 5)
+        self.initLobeSigmaGuess = wx.TextCtrl(self, -1, '%1.6G' % defaultVal, size=(80, -1))
+        row4.Add(self.initLobeSigmaGuess, 0, wx.ALIGN_CENTER_VERTICAL | wx.ALL, 5)
+        main_sizer.Add(row4, 0, wx.EXPAND | wx.ALL, 0)
+
+        # Buttons
+        btSizer = wx.StdDialogButtonSizer()
+        btn_ok = wx.Button(self, wx.ID_OK)
+        btn_ok.SetDefault()
+        btSizer.AddButton(btn_ok)
+        btn_cancel = wx.Button(self, wx.ID_CANCEL)
+        btSizer.AddButton(btn_cancel)
+        btSizer.Realize()
+        main_sizer.Add(btSizer, 0, wx.ALIGN_CENTER | wx.ALL, 5)
+
+        self.SetSizer(main_sizer)
+        main_sizer.Fit(self)
+        

--- a/double_helix/image_modules/DH_calibration.py
+++ b/double_helix/image_modules/DH_calibration.py
@@ -34,15 +34,27 @@ class DHCalibrator(Plugin):
         import os
         from double_helix.z_mapping import calibrate_double_helix_psf
         from double_helix.z_range_dialog import ZRangeDialog
+        from double_helix.detection_params_dialog import DetectionParamsDialog
         
         # query user for type of calibration
         # ftypes = ['Double Helix Theta', 'Double Helix Separate Gaussians']  # , 'AstigGaussGPUFitFR']
         # fit_type_dlg = wx.SingleChoiceDialog(self.dsviewer, 'Fit-type selection', 'Fit-type selection', ftypes)
         # fit_type_dlg.ShowModal()
         # fit_mod = ftypes[fit_type_dlg.GetSelection()]
+
         fit_mod = 'double_helix.DoubleGaussFit'
 
-        results = calibrate_double_helix_psf(self.dsviewer.image, fit_mod)
+        # create dialog for user to input detection parameters
+        # detection parameters then passed to calibrate_double_helix_psf
+        detection_params_dialog = DetectionParamsDialog(None, defaultVal=0)
+        succ = detection_params_dialog.ShowModal()
+        if succ == wx.ID_OK:
+            roiHalfSize = int(detection_params_dialog.roiHalfSize.GetValue())
+            initLobeSepGuess = float(detection_params_dialog.initLobeSepGuess.GetValue())
+            initLobeSigmaGuess = float(detection_params_dialog.initLobeSigmaGuess.GetValue())
+            filterSigma = float(detection_params_dialog.detectionFilterSigma.GetValue())
+
+        results = calibrate_double_helix_psf(self.dsviewer.image, fit_mod, roi_half_size=roiHalfSize, filter_sigma=filterSigma, LobseSepGuess=initLobeSepGuess, SigmaGuess=initLobeSigmaGuess)
 
         # do plotting
         plt.ioff()

--- a/double_helix/z_mapping.py
+++ b/double_helix/z_mapping.py
@@ -5,7 +5,7 @@ from scipy import ndimage
 from scipy.interpolate import LSQUnivariateSpline
 import math
 
-def calibrate_double_helix_psf(image, fit_module, roi_half_size=11):
+def calibrate_double_helix_psf(image, fit_module, roi_half_size=11, filter_sigma=5.0, LobseSepGuess=1000, SigmaGuess=200):
     """Generate Z vs theta calibration information from an PSF image stack
 
     Parameters
@@ -18,8 +18,14 @@ def calibrate_double_helix_psf(image, fit_module, roi_half_size=11):
         FitFactory to use when fitting each frame. At the moment, only supports
         DoubleHelix_Theta
     roi_half_size : int, optional
-        half size of fitting ROI, by default 11 which results in 11 * 2 + 1 = 23
+        half size of fitting ROI and half size of convolution kernels, by default 11 which results in 11 * 2 + 1 = 23
         pixel ROI.
+    filter_sigma : float, optional
+        sigma in pixels of G2, H2 filter functions, by default 5.0
+    LobseSepGuess : float, optional
+        Initial guess for the lobe separation in nm, by default 1000
+    SigmaGuess : float, optional
+        Initial guess for the lobe sigma in nm, by default 200
 
     Returns
     -------
@@ -44,21 +50,28 @@ def calibrate_double_helix_psf(image, fit_module, roi_half_size=11):
 
     results = []
 
+    # save detector parameters as dictionary that will be added to metadata used for FromPoint fitting
+    detection_params = {
+        'Analysis.ROISize': roi_half_size,
+        'Analysis.DetectionFilterSigma': filter_sigma,
+        'Analysis.LobeSepGuess': LobseSepGuess,
+        'Analysis.SigmaGuess': SigmaGuess
+    }
     for chan_ind in range(image.data_xyztc.shape[3]):
-        res = FitPoints(roiHalfSize=roi_half_size,
+        mod = FitPoints(roiHalfSize=roi_half_size,
                         fitModule=fit_module, 
-                        channel=chan_ind).apply_simple(
-                                            inputImage=image, 
-                                            inputPositions=obj_positions,
-                                            )
-        
+                        channel=chan_ind,
+                        parameters=detection_params)
+        res = mod.apply_simple(inputImage=image, inputPositions=obj_positions)
+
+
         results.append({
                 'theta': res['fitResults_theta'].tolist(),
                 'lobesep': res['fitResults_lobesep'].tolist(),
                 'sigma': res['fitResults_sigma'].tolist(),
                 'z': obj_positions['z'].tolist(),
             })
-
+   
     return results
 
 def lookup_dh_z(fres, calibration, rough_knot_spacing=101., plot=False):


### PR DESCRIPTION
DH PSF calibration did not function as intended as it used default detection parameters to detect PSFs in z stack and fit them, leading to bad calibrations.

To fix this 

1) created detection_params_dialog.py which is used in DH_calibrations.OnCalibrate. When user clicks Calibrate DHPSF, they are prompted to enter the detection parameters they would like to use for ROISize, initial lobe sep guess, initial lobe sigma guess, and filter sigma. These values are then passed to calibrate_double_helix_psf.

2) In calibrate_double_helix_psf, the detection parameters are saved as a dictionary that allow the parameters to be passed to FitPoints, ensuring that the fitfactory is initialized with the appropriate detection parameters.

3) In DoubleGaussFit.FromPoint, a line that was trying to set the Roi Half Size is removed as it is now unneccssary. 