### PR TITLE
add XY row/col alignment with PYME to unit tests, bring into alignment

### DIFF
--- a/double_helix/recipes/DH_mappings.py
+++ b/double_helix/recipes/DH_mappings.py
@@ -149,10 +149,12 @@ class DetectDoubleHelices(ModuleBase):
             for z_ind in range(im.data_xyztc.shape[2]):
                 for t_ind in range(im.data_xyztc.shape[3]):
                     frame = im.data_xyztc[:, :, z_ind, t_ind, c_ind]
-                    strength_image, angle_image = detector.filter_frame(frame.squeeze())
+                    # transpose frame because detector didn't originally match PYME XY convention
+                    strength_image, angle_image = detector.filter_frame(frame.squeeze().T)
                     strength[:, :, z_ind, t_ind, c_ind] = strength_image
                     noise_sigma = fitTask.calcSigma(im.mdh, frame)
-                    row, col, angle = detector.extract_candidates(strength_image, angle_image, self.thresh * noise_sigma.squeeze())
+                    row, col, angle = detector.extract_candidates(strength_image, angle_image,
+                                                                detector.normFactor * (self.thresh * noise_sigma.T.squeeze())**2)
                     r = np.append(r, row)
                     c = np.append(c, col)
                     theta = np.append(theta, angle)
@@ -161,7 +163,10 @@ class DetectDoubleHelices(ModuleBase):
                     ci = np.append(ci, [c_ind] * len(row))
         
         detections = DictSource({
-            'x': r*im.voxelsize_nm.x, 'y': c*im.voxelsize_nm.y, 'angle': theta, 'z_index': zi, 't': ti, 'probe': ci,
+            # NOTE - XY vs RC trickery to match PYME convention.
+            'x': c*im.voxelsize_nm.y, # Would be r*im.voxelsize_nm.x, but swap here to match PYME convention
+            'y': r*im.voxelsize_nm.x, # Would be c*im.voxelsize_nm.y, but swap here to match PYME convention
+            'angle': theta, 'z_index': zi, 't': ti, 'probe': ci,
             'z': zi * im.voxelsize_nm.z
         })
         detections.mdh = NestedClassMDHandler(im.mdh)

--- a/double_helix/z_mapping.py
+++ b/double_helix/z_mapping.py
@@ -45,8 +45,8 @@ def calibrate_double_helix_psf(image, fit_module, roi_half_size=11, filter_sigma
     obj_positions['x'] = vs_x_nm * 0.5 * image.data_xyztc.shape[0] * np.ones(n_steps)
     obj_positions['y'] = vs_y_nm * 0.5 * image.data_xyztc.shape[1] * np.ones(n_steps)
     obj_positions['t'] = np.arange(image.data.shape[2])
-    z = np.arange(image.data_xyztc.shape[2]) * image.mdh['voxelsize.z'] * 1.e3  # [um -> nm]
-    obj_positions['z'] = z - z.mean()
+    z = (image.mdh['Origin.z'] + np.arange(image.data_xyztc.shape[2]) * image.mdh['voxelsize.z']) * 1.e3  # [um -> nm]
+    obj_positions['z'] = z #  - z.mean()
 
     results = []
 

--- a/tests/test_coordinate_conventions.py
+++ b/tests/test_coordinate_conventions.py
@@ -74,21 +74,7 @@ acquired_theta = np.hstack([
     trimmed_theta - focus_step_theta  # theta decreases due to rotation
 ])
 
-# Generate test image stack
-test_stack_arr = np.empty(
-    (2 * md['Analysis.ROISize'] + 1, 2 * md['Analysis.ROISize'] + 1, len(acquired_theta)),
-    float
-)
-for zind in range(len(acquired_theta)):
-    test_stack_arr[:, :, zind], _, _, _ = DoubleGaussFit.DumbellFitFactory.evalModel(
-        [A0, A0, 0, 0, acquired_theta[zind], md['Analysis.LobeSepGuess'],
-         md['Analysis.SigmaGuess'], 20],
-        md,
-        x=md['voxelsize.x'] * md['Analysis.ROISize'],
-        y=md['voxelsize.y'] * md['Analysis.ROISize'],
-        roiHalfSize=md['Analysis.ROISize']
-    )
-test_stack = ImageStack(test_stack_arr, md)
+
 
 # Create ground truth data source with actual sample positions (as if focus shift had not occurred)
 gt_dict = {
@@ -210,3 +196,209 @@ def test_z_focus_mapping():
         
     finally:
         os.unlink(temp_path)
+
+
+def test_DoubleGaussFit_FindAndFit_XYTheta():
+    """
+    Make sure that DoubleGaussFit.DumbellFitFactory.FindAndFit can find the correct X, Y, Theta position of Double Helices in a test stack with
+    multiple Z positions, and a lateral offset which would cause an error for an incorrectly transposed stack.
+    """
+    # Generate a test image stack with an X offset to check for correct handling of XY conventions
+    # especially combined with theta definitions.
+    x_shift = 1.25 * md.voxelsize_nm.x  # 1.25 pixel shift in X
+    test_stack_arr = np.empty(
+        (2 * md['Analysis.ROISize'] + 1, 2 * md['Analysis.ROISize'] + 1, len(trimmed_theta)),
+        float
+    )
+    for zind in range(len(trimmed_theta)):
+        test_stack_arr[:, :, zind], _, _, _ = DoubleGaussFit.DumbellFitFactory.evalModel(
+            [A0, A0, x_shift, 0, trimmed_theta[zind], md['Analysis.LobeSepGuess'],
+            md['Analysis.SigmaGuess'], 20],
+            md,
+            x=md['voxelsize.x'] * md['Analysis.ROISize'],  # Add X offset
+            y=md['voxelsize.y'] * md['Analysis.ROISize'],
+            roiHalfSize=md['Analysis.ROISize']
+        )
+    test_stack = ImageStack(test_stack_arr, md)
+
+    # Create metadata with tIndex for results packing
+    # tIndex must be set as a direct attribute - DictMDHandler does not expose
+    # dict keys as attributes, so metadata.tIndex would otherwise return None.
+    test_md = MetaDataHandler.DictMDHandler(md)
+    test_md.tIndex = 0
+
+    # Run FindAndFit on each z-frame and collect fit results
+    roi_size = md['Analysis.ROISize']
+    noise_sigma = np.ones((2 * roi_size + 1, 2 * roi_size + 1, 1))
+
+    x0_results = []
+    y0_results = []
+    theta_results = []
+
+    for zind in range(len(trimmed_theta)):
+        frame_data = test_stack_arr[:, :, zind:zind + 1]  # (x, y, 1) in PYME convention
+        factory = DoubleGaussFit.DumbellFitFactory(frame_data, test_md, noiseSigma=noise_sigma)
+        results = factory.FindAndFit(threshold=1.0, cameraMaps=None)
+
+        assert len(results) == 1, (
+            f"Expected exactly 1 detection at z-index {zind}, found {len(results)}"
+        )
+
+        x0_results.append(float(results['fitResults']['x0'][0]))
+        y0_results.append(float(results['fitResults']['y0'][0]))
+        theta_results.append(float(results['fitResults']['theta'][0]))
+
+    x0_arr = np.array(x0_results)
+    y0_arr = np.array(y0_results)
+    theta_arr = np.array(theta_results)
+
+    # Check that the x_shift appears in x0, not y0.
+    # The evalModel grid has the same origin for x and y, so x0 - y0 should equal x_shift.
+    # A transposed data array would produce x0 - y0 ≈ -x_shift instead, causing this to fail.
+    np.testing.assert_allclose(
+        x0_arr - y0_arr,
+        x_shift * np.ones(len(trimmed_theta)),
+        atol=0.1 * md.voxelsize_nm.x,  # 0.1 pixel tolerance [nm]
+        err_msg="x0 - y0 does not equal x_shift: x/y convention may be transposed"
+    )
+
+    # Check that theta is correctly recovered (pi-periodic, since A0 == A1 makes theta
+    # and theta+pi produce identical PSFs)
+    d = (theta_arr - trimmed_theta) % np.pi  # wrapped to [0, pi)
+    theta_err = np.minimum(d, np.pi - d)      # wrapped to [0, pi/2]
+    assert np.all(theta_err < 0.1), (
+        f"Theta not recovered within 0.1 rad: max error = {theta_err.max():.3f} rad"
+    )
+
+
+def test_DoubleGaussFit_FromPoint_XYTheta():
+    """
+    Make sure that DoubleGaussFit.DumbellFitFactory.FromPoint can find the correct X, Y, Theta position of a Double Helix in a test stack with
+    multiple Z positions, and a lateral offset which would cause an error for an incorrectly transposed stack.
+    """
+    x_shift = 1.25 * md.voxelsize_nm.x  # 1.25 pixel shift in X
+    roi_size = md['Analysis.ROISize']
+    test_stack_arr = np.empty(
+        (2 * roi_size + 1, 2 * roi_size + 1, len(trimmed_theta)),
+        float
+    )
+    for zind in range(len(trimmed_theta)):
+        test_stack_arr[:, :, zind], _, _, _ = DoubleGaussFit.DumbellFitFactory.evalModel(
+            [A0, A0, x_shift, 0, trimmed_theta[zind], md['Analysis.LobeSepGuess'],
+             md['Analysis.SigmaGuess'], 20],
+            md,
+            x=md['voxelsize.x'] * roi_size,
+            y=md['voxelsize.y'] * roi_size,
+            roiHalfSize=roi_size
+        )
+    
+    test_md = MetaDataHandler.DictMDHandler(md)
+    # tIndex must be a direct attribute - DictMDHandler does not expose dict keys as attributes
+    test_md.tIndex = 0
+
+    noise_sigma = np.ones((2 * roi_size + 1, 2 * roi_size + 1, 1))
+
+    x0_results = []
+    y0_results = []
+    theta_results = []
+
+    for zind in range(len(trimmed_theta)):
+        frame_data = test_stack_arr[:, :, zind:zind + 1]  # (x, y, 1) in PYME convention
+        factory = DoubleGaussFit.DumbellFitFactory(frame_data, test_md, noiseSigma=noise_sigma)
+        # Pass the array center as the hint; roiHalfSize=roi_size covers the full frame
+        result = factory.FromPoint(x=roi_size, y=roi_size, roiHalfSize=roi_size)
+
+        x0_results.append(float(result['fitResults']['x0']))
+        y0_results.append(float(result['fitResults']['y0']))
+        theta_results.append(float(result['fitResults']['theta']))
+
+    x0_arr = np.array(x0_results)
+    y0_arr = np.array(y0_results)
+    theta_arr = np.array(theta_results)
+
+    # Check that the x_shift appears in x0, not y0.
+    # A transposed data array would produce x0 - y0 ≈ -x_shift instead.
+    np.testing.assert_allclose(
+        x0_arr - y0_arr,
+        x_shift * np.ones(len(trimmed_theta)),
+        atol=0.1 * md.voxelsize_nm.x,  # 0.1 pixel tolerance [nm]
+        err_msg="x0 - y0 does not equal x_shift: x/y convention may be transposed"
+    )
+
+    # Check that theta is correctly recovered (pi-periodic, since A0 == A1 makes theta
+    # and theta+pi produce identical PSFs)
+    d = (theta_arr - trimmed_theta) % np.pi  # wrapped to [0, pi)
+    theta_err = np.minimum(d, np.pi - d)      # wrapped to [0, pi/2]
+    assert np.all(theta_err < 0.1), (
+        f"Theta not recovered within 0.1 rad: max error = {theta_err.max():.3f} rad"
+    )
+
+
+def test_DoubleHelixFindAndFit_XYTheta():
+    """
+    Make sure that double_helix.recipes.DH_mappings.DetectDoubleHelices has the correct X, Y, and Theta conventions, by looking
+    at a test stack with multiple Z positions and a lateral offset which would cause an error for an incorrectly transposed stack.
+    """
+    from double_helix.recipes.DH_mappings import DetectDoubleHelices
+    from unittest.mock import patch
+    import numpy as np
+
+    x_shift = 1.25 * md.voxelsize_nm.x  # 1.25 pixel shift in X
+    roi_size = md['Analysis.ROISize']
+    n_frames = len(trimmed_theta)
+
+    # Build z-stack with one DH per frame, each with the same x_shift but varying theta
+    test_stack_arr = np.empty(
+        (2 * roi_size + 1, 2 * roi_size + 1, n_frames),
+        float
+    )
+    for zind in range(n_frames):
+        test_stack_arr[:, :, zind], _, _, _ = DoubleGaussFit.DumbellFitFactory.evalModel(
+            [A0, A0, x_shift, 0, trimmed_theta[zind], md['Analysis.LobeSepGuess'],
+             md['Analysis.SigmaGuess'], 20],
+            md,
+            x=md['voxelsize.x'] * roi_size,
+            y=md['voxelsize.y'] * roi_size,
+            roiHalfSize=roi_size
+        )
+
+    test_stack = ImageStack(test_stack_arr, md, haveGUI=False)
+
+    # Patch fitTask.calcSigma to return a flat noise sigma of 1.0 per pixel,
+    # avoiding dependency on camera map files in the test environment.
+    flat_sigma = np.ones((2 * roi_size + 1, 2 * roi_size + 1))
+    with patch('PYME.localization.remFitBuf.fitTask.calcSigma', return_value=flat_sigma):
+        outputs = DetectDoubleHelices(
+            lobe_sep_nm=md['Analysis.LobeSepGuess'],
+            lobe_sigma_nm=md['Analysis.SigmaGuess'],
+            filter_sigma_px=md['Analysis.DetectionFilterSigma'],
+            fit_roi_half_size=roi_size,
+            thresh=1.0,
+        ).apply(input_image=test_stack)
+
+    detections = outputs['dh_detections']
+
+    assert len(detections['x']) == n_frames, (
+        f"Expected {n_frames} detections (one per frame), got {len(detections['x'])}"
+    )
+
+    x_arr = np.array(detections['x'])
+    y_arr = np.array(detections['y'])
+    angle_arr = np.array(detections['angle'])
+
+    # Check that the x_shift appears in x, not y.
+    # Detection is at integer pixels, so tolerance is 1 pixel.
+    # A transposed frame would produce x - y ≈ -x_shift instead, failing this assertion.
+    np.testing.assert_allclose(
+        x_arr - y_arr,
+        x_shift * np.ones(n_frames),
+        atol=md.voxelsize_nm.x,  # 1 pixel tolerance for integer detection
+        err_msg="x - y does not equal x_shift: x/y convention may be transposed"
+    )
+
+    # Check that angle is correctly recovered (pi-periodic)
+    d = (angle_arr - trimmed_theta) % np.pi  # wrapped to [0, pi)
+    angle_err = np.minimum(d, np.pi - d)      # wrapped to [0, pi/2]
+    assert np.all(angle_err < 0.1), (
+        f"angle not recovered within 0.1 rad: max error = {angle_err.max():.3f} rad"
+    )

--- a/tests/test_coordinate_conventions.py
+++ b/tests/test_coordinate_conventions.py
@@ -1,0 +1,136 @@
+
+import numpy as np
+from PYME.IO.image import ImageStack
+from PYME.IO import MetaDataHandler
+from double_helix import DoubleGaussFit
+
+# assume theta ranges from 0 to pi, and z from -1000 to 1000 nm
+step_size = 60  # [nm]
+_z = np.arange(-1000, 1000.1, step_size)  # [nm]
+_z_um = _z / 1e3  # [um]
+_theta = np.linspace(0, 0.99 * np.pi, len(_z))  # [rad]
+
+
+md = MetaDataHandler.SimpleMDHandler()
+md['Analysis.ROISize'] = 10  # actually 0.5 pix less than half size.
+md['voxelsize.units'] = 'um'
+md['voxelsize.x'] = 0.12
+md['voxelsize.y'] = 0.12
+md['voxelsize.z'] = step_size / 1e3  # [um]
+md['Analysis.SigmaGuess'] = 200  # Double Helix Lobe Sigma Guess [nm]
+md['Analysis.LobeSepGuess'] = 1050  # Double Helix Lobe
+md['Analysis.DetectionFilterSigma'] = 5  # Detection Filter Sigma (in px)
+md['Origin.z'] = _z_um[0]  # set Z origin to match the first Z position in the stack
+A0 = 500
+# simulate an image stack to match this calibration
+psf_stack_arr = np.empty((2 * md['Analysis.ROISize'] + 1, 2 * md['Analysis.ROISize'] + 1, len(_z)), float)
+for zind in range(len(_z)):
+    psf_stack_arr[:, :, zind], _, _, _ = DoubleGaussFit.DumbellFitFactory.evalModel(
+        [A0, A0, 0, 0, _theta[zind], md['Analysis.LobeSepGuess'], md['Analysis.SigmaGuess'], 20], 
+        md, x=md['voxelsize.x']*md['Analysis.ROISize'], y=md['voxelsize.y']*md['Analysis.ROISize'], roiHalfSize=md['Analysis.ROISize']
+    )
+
+
+
+# # simulate a Z stepped acquisition, where the focus is stepped in Z while the sample is fixed,
+# # so theta unwinds as Z increases
+step_size_ind = 5
+focus_step_z = step_size_ind * step_size  # [nm]
+# make sure that we don't wrap theta by subtracting off too much. Clip the whole thing by step_size_ind indices
+trimmed_theta = _theta[step_size_ind:-step_size_ind]
+trimmed_z = _z[step_size_ind:-step_size_ind]
+focus_step_theta = trimmed_theta[step_size_ind] - trimmed_theta[0]  # [rad]
+focus = np.hstack([np.zeros_like(trimmed_z), step_size_ind * step_size * np.ones_like(trimmed_z)])  # [nm])
+acquired_theta = np.hstack([trimmed_theta, trimmed_theta - focus_step_theta])  # [rad]
+
+
+test_stack_arr = np.empty((2 * md['Analysis.ROISize'] + 1, 2 * md['Analysis.ROISize'] + 1, len(acquired_theta)), float)
+for zind in range(len(acquired_theta)):
+    test_stack_arr[:, :, zind], _, _, _ = DoubleGaussFit.DumbellFitFactory.evalModel(
+        [A0, A0, 0, 0, acquired_theta[zind], md['Analysis.LobeSepGuess'], md['Analysis.SigmaGuess'], 20], 
+        md, x=md['voxelsize.x']*md['Analysis.ROISize'], y=md['voxelsize.y']*md['Analysis.ROISize'], roiHalfSize=md['Analysis.ROISize']
+    )
+test_stack = ImageStack(test_stack_arr, md)
+from PYME.IO.tabular import DictSource
+gt_dict = {
+    'z': np.hstack([trimmed_z, trimmed_z + focus_step_z]), 
+    'x': np.zeros_like(focus), 'y': np.zeros_like(focus), 
+    'fitResults_theta': acquired_theta, 'fitError_theta': 0.001 * np.ones_like(acquired_theta),
+    'fitResults_sigma': md['Analysis.SigmaGuess'] * np.ones_like(acquired_theta),
+    'fitResults_lobesep': md['Analysis.LobeSepGuess'] * np.ones_like(acquired_theta),
+    'fitResults_A0': A0 * np.ones_like(acquired_theta),
+    'fitResults_A1': A0 * np.ones_like(acquired_theta),
+    'startParams_x0': np.zeros_like(acquired_theta),
+    'startParams_y0': np.zeros_like(acquired_theta),
+    'fitError_sigma': np.ones_like(acquired_theta),
+    'fitError_lobesep': np.ones_like(acquired_theta),
+}
+gt = DictSource(gt_dict)
+gt.mdh = MetaDataHandler.DictMDHandler(md)
+gt_focus = gt_dict.copy()
+gt_focus['z'] = focus
+gt_focus = DictSource(gt_focus)
+gt_focus.mdh = MetaDataHandler.DictMDHandler(md)
+
+def test_calibration_z():
+    from double_helix.z_mapping import calibrate_double_helix_psf
+    # NOTE - PYME has a transpose between localizations and images
+    psf_stack = ImageStack(psf_stack_arr, md, haveGUI=False)
+    cal = calibrate_double_helix_psf(psf_stack, 'double_helix.DoubleGaussFit', roi_half_size=md['Analysis.ROISize'], filter_sigma=md['Analysis.DetectionFilterSigma'], lobe_sep_guess=md['Analysis.LobeSepGuess'], lobe_sigma_guess=md['Analysis.SigmaGuess'])
+    c_ind = 0  # which channel to test (if multiple channels in calibration)
+
+    unwrapped_theta_gt = np.unwrap(_theta, np.pi/2, period=np.pi)
+    unwrapped_theta_cal = np.unwrap(np.asarray(cal[c_ind]['theta']), np.pi/2, period=np.pi)
+
+    # check that Z positions in calibration match expected Z positions (which are just _z)
+    np.testing.assert_almost_equal(_z, cal[c_ind]['z'], decimal=1)
+    
+    # import matplotlib.pyplot as plt
+    # plt.plot(_z, _theta, label='gt', linewidth=5)
+    # plt.plot(_z, unwrapped_theta_gt, label='gt unwrapped')
+    # plt.plot(cal[c_ind]['z'], unwrapped_theta_cal, label='cal unwrapped')
+    # plt.legend()
+    # plt.show()
+    # # theta_spline = LSQUnivariateSpline(z_valid, unwrapped_theta_cal, knots, ext='const')
+    # # theta_cal = theta_spline(z_v)
+
+    np.testing.assert_almost_equal(unwrapped_theta_cal, unwrapped_theta_gt, decimal=1)  # check that theta vs z relationship in calibration matches expected theta vs z relationship (which is just _theta vs _z)
+
+
+def test_z_focus_mapping():
+    from double_helix.z_mapping import calibrate_double_helix_psf
+    # NOTE - PYME has a transpose between localizations and images
+    psf_stack = ImageStack(psf_stack_arr, md, haveGUI=False)
+    cal = calibrate_double_helix_psf(psf_stack, 'double_helix.DoubleGaussFit', roi_half_size=md['Analysis.ROISize'], filter_sigma=md['Analysis.DetectionFilterSigma'], lobe_sep_guess=md['Analysis.LobeSepGuess'], lobe_sigma_guess=md['Analysis.SigmaGuess'])
+    c_ind = 0  # which channel to test (if multiple channels in calibration)
+
+    # look up the Z position based on the "acquired_theta" values, and check that it matches the expected Z positions (which are just _z shifted by the focus step)
+    from double_helix.recipes.DH_mappings import DoubleHelixMapZ
+
+    # save cal to temp location to test loading from file in mapping function
+    import json
+    import tempfile
+    import os
+
+    # add z_range to each channel's calibration (required by lookup_dh_z)
+    for chan_cal in cal:
+        chan_cal['z_range'] = (_z[0] - 1, _z[-1] + 1)
+
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.dh_json', delete=False, encoding='utf8') as f:
+        temp_path = f.name
+        json.dump(cal, f)
+    # file must be closed before unifiedIO.read can open it on Windows
+    try:
+        # KEY POINT:
+        # "z" input to DoubleHelixMapZ is the "focus" Z, i.e. obj position.
+        recipe_results = DoubleHelixMapZ(calibration_location=temp_path,
+                                 target_knot_spacing=2 * step_size + 1).apply(input_name=gt_focus)  # ['dh_localizations']
+        # "z" output is "dh_z + z_input"
+    finally:
+        os.unlink(temp_path)
+    mapped = recipe_results['dh_localizations']
+    plot = recipe_results['dh_z_lookup_plot']
+
+    # mapping Z with DH should recover the original Z positions, with no focus step
+    np.testing.assert_allclose(mapped['z'], np.hstack([trimmed_z, trimmed_z]), atol=1.1)
+

--- a/tests/test_coordinate_conventions.py
+++ b/tests/test_coordinate_conventions.py
@@ -2,60 +2,101 @@
 import numpy as np
 from PYME.IO.image import ImageStack
 from PYME.IO import MetaDataHandler
+from PYME.IO.tabular import DictSource
 from double_helix import DoubleGaussFit
 
-# assume theta ranges from 0 to pi, and z from -1000 to 1000 nm
+# ============================================================================
+# Setup: Calibration PSF Stack
+# ============================================================================
+# Simulate a calibration with theta ranging from 0 to pi and z from -1000 to 1000 nm
 step_size = 60  # [nm]
 _z = np.arange(-1000, 1000.1, step_size)  # [nm]
 _z_um = _z / 1e3  # [um]
 _theta = np.linspace(0, 0.99 * np.pi, len(_z))  # [rad]
 
-
+# Setup metadata for the calibration
 md = MetaDataHandler.SimpleMDHandler()
-md['Analysis.ROISize'] = 10  # actually 0.5 pix less than half size.
+md['Analysis.ROISize'] = 10  # actually 0.5 pix less than half size
 md['voxelsize.units'] = 'um'
 md['voxelsize.x'] = 0.12
 md['voxelsize.y'] = 0.12
 md['voxelsize.z'] = step_size / 1e3  # [um]
 md['Analysis.SigmaGuess'] = 200  # Double Helix Lobe Sigma Guess [nm]
-md['Analysis.LobeSepGuess'] = 1050  # Double Helix Lobe
-md['Analysis.DetectionFilterSigma'] = 5  # Detection Filter Sigma (in px)
+md['Analysis.LobeSepGuess'] = 1050  # Double Helix Lobe separation [nm]
+md['Analysis.DetectionFilterSigma'] = 5  # Detection Filter Sigma [px]
 md['Origin.z'] = _z_um[0]  # set Z origin to match the first Z position in the stack
-A0 = 500
-# simulate an image stack to match this calibration
-psf_stack_arr = np.empty((2 * md['Analysis.ROISize'] + 1, 2 * md['Analysis.ROISize'] + 1, len(_z)), float)
+A0 = 500  # amplitude
+
+# Generate PSF stack: for each z position, create a synthetic double helix image
+# with the corresponding theta
+psf_stack_arr = np.empty(
+    (2 * md['Analysis.ROISize'] + 1, 2 * md['Analysis.ROISize'] + 1, len(_z)), 
+    float
+)
 for zind in range(len(_z)):
     psf_stack_arr[:, :, zind], _, _, _ = DoubleGaussFit.DumbellFitFactory.evalModel(
-        [A0, A0, 0, 0, _theta[zind], md['Analysis.LobeSepGuess'], md['Analysis.SigmaGuess'], 20], 
-        md, x=md['voxelsize.x']*md['Analysis.ROISize'], y=md['voxelsize.y']*md['Analysis.ROISize'], roiHalfSize=md['Analysis.ROISize']
+        [A0, A0, 0, 0, _theta[zind], md['Analysis.LobeSepGuess'], 
+         md['Analysis.SigmaGuess'], 20],
+        md, 
+        x=md['voxelsize.x'] * md['Analysis.ROISize'],
+        y=md['voxelsize.y'] * md['Analysis.ROISize'],
+        roiHalfSize=md['Analysis.ROISize']
     )
 
 
+# ============================================================================
+# Setup: Test stack with focus step
+# ============================================================================
+# Simulate a real acquisition with two imaging sessions separated by a focus step
+# Before focus step: sample at z positions [step_size_ind, ..., -step_size_ind]
+# After focus step: same sample imaged again, but objective shifted by focus_step_z
+# The double helix rotates with the focus step, so theta adjusts accordingly
 
-# # simulate a Z stepped acquisition, where the focus is stepped in Z while the sample is fixed,
-# # so theta unwinds as Z increases
-step_size_ind = 5
-focus_step_z = step_size_ind * step_size  # [nm]
-# make sure that we don't wrap theta by subtracting off too much. Clip the whole thing by step_size_ind indices
+step_size_ind = 5  # number of steps for the focus shift
+focus_step_z = step_size_ind * step_size  # [nm] objective position change
+
+# Trim indices to avoid theta wrapping complications (use middle portion of calibration)
 trimmed_theta = _theta[step_size_ind:-step_size_ind]
 trimmed_z = _z[step_size_ind:-step_size_ind]
+
+# The focus step introduces a rotation in the double helix PSF
 focus_step_theta = trimmed_theta[step_size_ind] - trimmed_theta[0]  # [rad]
-focus = np.hstack([np.zeros_like(trimmed_z), step_size_ind * step_size * np.ones_like(trimmed_z)])  # [nm])
-acquired_theta = np.hstack([trimmed_theta, trimmed_theta - focus_step_theta])  # [rad]
 
+# Create the focus positions: zero for first session, focus_step_z for second
+focus_positions = np.hstack([
+    np.zeros_like(trimmed_z),
+    step_size_ind * step_size * np.ones_like(trimmed_z)
+])
 
-test_stack_arr = np.empty((2 * md['Analysis.ROISize'] + 1, 2 * md['Analysis.ROISize'] + 1, len(acquired_theta)), float)
+# Acquired theta: same structure imaged twice, but rotated on second pass 
+acquired_theta = np.hstack([
+    trimmed_theta,
+    trimmed_theta - focus_step_theta  # theta decreases due to rotation
+])
+
+# Generate test image stack
+test_stack_arr = np.empty(
+    (2 * md['Analysis.ROISize'] + 1, 2 * md['Analysis.ROISize'] + 1, len(acquired_theta)),
+    float
+)
 for zind in range(len(acquired_theta)):
     test_stack_arr[:, :, zind], _, _, _ = DoubleGaussFit.DumbellFitFactory.evalModel(
-        [A0, A0, 0, 0, acquired_theta[zind], md['Analysis.LobeSepGuess'], md['Analysis.SigmaGuess'], 20], 
-        md, x=md['voxelsize.x']*md['Analysis.ROISize'], y=md['voxelsize.y']*md['Analysis.ROISize'], roiHalfSize=md['Analysis.ROISize']
+        [A0, A0, 0, 0, acquired_theta[zind], md['Analysis.LobeSepGuess'],
+         md['Analysis.SigmaGuess'], 20],
+        md,
+        x=md['voxelsize.x'] * md['Analysis.ROISize'],
+        y=md['voxelsize.y'] * md['Analysis.ROISize'],
+        roiHalfSize=md['Analysis.ROISize']
     )
 test_stack = ImageStack(test_stack_arr, md)
-from PYME.IO.tabular import DictSource
+
+# Create ground truth data source with actual sample positions (as if focus shift had not occurred)
 gt_dict = {
-    'z': np.hstack([trimmed_z, trimmed_z + focus_step_z]), 
-    'x': np.zeros_like(focus), 'y': np.zeros_like(focus), 
-    'fitResults_theta': acquired_theta, 'fitError_theta': 0.001 * np.ones_like(acquired_theta),
+    'z': np.hstack([trimmed_z, trimmed_z]),  # actual sample z (same structure twice)
+    'x': np.zeros_like(focus_positions),
+    'y': np.zeros_like(focus_positions),
+    'fitResults_theta': acquired_theta,  # what we actually observed
+    'fitError_theta': 0.001 * np.ones_like(acquired_theta),
     'fitResults_sigma': md['Analysis.SigmaGuess'] * np.ones_like(acquired_theta),
     'fitResults_lobesep': md['Analysis.LobeSepGuess'] * np.ones_like(acquired_theta),
     'fitResults_A0': A0 * np.ones_like(acquired_theta),
@@ -67,70 +108,105 @@ gt_dict = {
 }
 gt = DictSource(gt_dict)
 gt.mdh = MetaDataHandler.DictMDHandler(md)
+
+# Create a version with focus positions instead of actual sample positions
+# (used for mapping - input to DoubleHelixMapZ is the objective/focus position)
 gt_focus = gt_dict.copy()
-gt_focus['z'] = focus
+gt_focus['z'] = focus_positions  # objective position, not sample position
 gt_focus = DictSource(gt_focus)
 gt_focus.mdh = MetaDataHandler.DictMDHandler(md)
-
+# ============================================================================
+# TEST 1: Calibration PSF Stack → Recovered Theta vs Z
+# ============================================================================
 def test_calibration_z():
+    """
+    Test that calibration from a PSF stack recovers the input theta vs z relationship.
+    
+    This test:
+    1. Creates a calibration by fitting each PSF slice to extract theta at each z
+    2. Checks that the recovered z positions match the input z positions
+    3. Checks that the theta vs z relationship is preserved (unwrapped)
+    """
     from double_helix.z_mapping import calibrate_double_helix_psf
-    # NOTE - PYME has a transpose between localizations and images
+    
     psf_stack = ImageStack(psf_stack_arr, md, haveGUI=False)
-    cal = calibrate_double_helix_psf(psf_stack, 'double_helix.DoubleGaussFit', roi_half_size=md['Analysis.ROISize'], filter_sigma=md['Analysis.DetectionFilterSigma'], lobe_sep_guess=md['Analysis.LobeSepGuess'], lobe_sigma_guess=md['Analysis.SigmaGuess'])
-    c_ind = 0  # which channel to test (if multiple channels in calibration)
+    cal = calibrate_double_helix_psf(
+        psf_stack,
+        'double_helix.DoubleGaussFit',
+        roi_half_size=md['Analysis.ROISize'],
+        filter_sigma=md['Analysis.DetectionFilterSigma'],
+        lobe_sep_guess=md['Analysis.LobeSepGuess'],
+        lobe_sigma_guess=md['Analysis.SigmaGuess']
+    )
+    c_ind = 0  # test first channel
 
+    # Unwrap theta to handle the 2π periodicity properly
     unwrapped_theta_gt = np.unwrap(_theta, np.pi/2, period=np.pi)
     unwrapped_theta_cal = np.unwrap(np.asarray(cal[c_ind]['theta']), np.pi/2, period=np.pi)
 
-    # check that Z positions in calibration match expected Z positions (which are just _z)
+    # Check that Z positions in calibration match expected Z positions
     np.testing.assert_almost_equal(_z, cal[c_ind]['z'], decimal=1)
     
-    # import matplotlib.pyplot as plt
-    # plt.plot(_z, _theta, label='gt', linewidth=5)
-    # plt.plot(_z, unwrapped_theta_gt, label='gt unwrapped')
-    # plt.plot(cal[c_ind]['z'], unwrapped_theta_cal, label='cal unwrapped')
-    # plt.legend()
-    # plt.show()
-    # # theta_spline = LSQUnivariateSpline(z_valid, unwrapped_theta_cal, knots, ext='const')
-    # # theta_cal = theta_spline(z_v)
-
-    np.testing.assert_almost_equal(unwrapped_theta_cal, unwrapped_theta_gt, decimal=1)  # check that theta vs z relationship in calibration matches expected theta vs z relationship (which is just _theta vs _z)
+    # Check that theta vs z relationship in calibration matches input relationship
+    np.testing.assert_almost_equal(unwrapped_theta_cal, unwrapped_theta_gt, decimal=1)
 
 
+# ============================================================================
+# TEST 2: Z Mapping with Focus Step → Recovered Sample Positions
+# ============================================================================
 def test_z_focus_mapping():
+    """
+    Test that Z mapping correctly recovers sample positions despite a focus step.
+    
+    This test simulates the scenario:
+    1. Sample contains multiple Z positions (of course)
+    2. Objective focuses to a different z (focus step)
+    3. Same sample structure is imaged again 
+
+    The mapping should recover that the sample z positions are the same before
+    and after the focus step, as if the step had never occurred.
+    """
     from double_helix.z_mapping import calibrate_double_helix_psf
-    # NOTE - PYME has a transpose between localizations and images
-    psf_stack = ImageStack(psf_stack_arr, md, haveGUI=False)
-    cal = calibrate_double_helix_psf(psf_stack, 'double_helix.DoubleGaussFit', roi_half_size=md['Analysis.ROISize'], filter_sigma=md['Analysis.DetectionFilterSigma'], lobe_sep_guess=md['Analysis.LobeSepGuess'], lobe_sigma_guess=md['Analysis.SigmaGuess'])
-    c_ind = 0  # which channel to test (if multiple channels in calibration)
-
-    # look up the Z position based on the "acquired_theta" values, and check that it matches the expected Z positions (which are just _z shifted by the focus step)
     from double_helix.recipes.DH_mappings import DoubleHelixMapZ
-
-    # save cal to temp location to test loading from file in mapping function
     import json
     import tempfile
     import os
 
-    # add z_range to each channel's calibration (required by lookup_dh_z)
+    # Generate calibration
+    psf_stack = ImageStack(psf_stack_arr, md, haveGUI=False)
+    cal = calibrate_double_helix_psf(
+        psf_stack,
+        'double_helix.DoubleGaussFit',
+        roi_half_size=md['Analysis.ROISize'],
+        filter_sigma=md['Analysis.DetectionFilterSigma'],
+        lobe_sep_guess=md['Analysis.LobeSepGuess'],
+        lobe_sigma_guess=md['Analysis.SigmaGuess']
+    )
+    c_ind = 0  # test first channel
+
+    # Add z_range to calibration (required by DoubleHelixMapZ)
     for chan_cal in cal:
         chan_cal['z_range'] = (_z[0] - 1, _z[-1] + 1)
 
+    # Save calibration to temporary file
     with tempfile.NamedTemporaryFile(mode='w', suffix='.dh_json', delete=False, encoding='utf8') as f:
         temp_path = f.name
         json.dump(cal, f)
-    # file must be closed before unifiedIO.read can open it on Windows
+    
     try:
-        # KEY POINT:
-        # "z" input to DoubleHelixMapZ is the "focus" Z, i.e. obj position.
-        recipe_results = DoubleHelixMapZ(calibration_location=temp_path,
-                                 target_knot_spacing=2 * step_size + 1).apply(input_name=gt_focus)  # ['dh_localizations']
-        # "z" output is "dh_z + z_input"
+        # Map z positions using the double helix mapping
+        # Input is objective position (focus), output is sample position (dh_z) plus input
+        recipe_results = DoubleHelixMapZ(
+            calibration_location=temp_path,
+            target_knot_spacing=2 * step_size + 1
+        ).apply(input_name=gt_focus)
+        
+        mapped = recipe_results['dh_localizations']
+        
+        # The mapping should recover that the sample is at the same z positions before
+        # and after the focus step (as if the focus step had not happened)
+        expected_z_mapped = np.hstack([trimmed_z, trimmed_z])
+        np.testing.assert_allclose(mapped['z'], expected_z_mapped, atol=1.1)
+        
     finally:
         os.unlink(temp_path)
-    mapped = recipe_results['dh_localizations']
-    plot = recipe_results['dh_z_lookup_plot']
-
-    # mapping Z with DH should recover the original Z positions, with no focus step
-    np.testing.assert_allclose(mapped['z'], np.hstack([trimmed_z, trimmed_z]), atol=1.1)
-


### PR DESCRIPTION
Major changes:
- in calibration, any Z offset present in PSF stack metadata was being ignored, and the average objective focus Z position was being subtracted. This is no longer the case, such that the calibration will carry-through any offset specified in the metadata.
- `recipes.DH_mappings.DetectDoubleHelices` now uses the `detector.normFactor` scaling applied to the noise map / threshold.
-  `recipes.DH_mappings.DetectDoubleHelices` X and Y conventions are now brought into alignment with PYME (and `DoubleGaussFit.DumbellFitFactory.FindAndFit`, `DoubleGaussFit.DumbellFitFactory.FromPoint`.