### PR TITLE
Add double_helix.SplineFit cubic spline fitter, and DH PSF extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This plugin has been developed in the [Moerner Lab](https://web.stanford.edu/gro
 ## Key Features
 - highly efficient detection of double-helix point-spread functions using just 7 (separable) convolutions
 - Double-gaussian localization fitting parameterized on lobe separation and orientation, which enables direct estimates of their uncertainties
+- Cubic spline localization fitting with initial Z guessed from detected orientation
 
 Read more: [_Efficient Double Helix Detection with Steerable Filters_. Barentine, A.E.S., Balaji, A., Moerner, W.E. (2025). bioRxiv 2025.08.14.670427](https://doi.org/10.1101/2025.08.14.670427)
 
@@ -40,13 +41,24 @@ double-helix-install-plugin
 It is imperative to have correct metadata for good localization. If your data was not acquired using PYME, please see PYME's [analyzing foreign data documentation](https://python-microscopy.org/doc/AnalysingForeignData.html).
 
 ### PSF calibration
-Calibrating your point-spread function is a great way to start. While this calibration is not necessary for fitting, it is used to eventually convert the orientation of the double-helix to a z position for a localized molecule.
-Additionally, calibrating your PSF will help determine optimal detection settings.
+Calibrating your point-spread function is a great way to start. While this calibration is not necessary for model-based fitting, it is used to eventually convert the orientation of the double-helix to a z position for a localized molecule.
+Additionally, calibrating your PSF will help determine optimal detection settings, and is necessary for spline-based fitting.
+
+#### Model based (Double Gaussian) fitting
 
 1. Open your bead stack in PYMEImage. If you already have a cropped Z-stack of a single bead, your "extracted PSF", proceed to the next step. If you have multiple beads in the same field of view, you may wish to enable the PYME `psfExtraction` module. The extraction process is described in the [PYME documentation](https://python-microscopy.org/doc/PSFExtraction.html).
 2. Once you have your extracted PSF open in PYMEImage, load the double-helix calibration module by clicking on `DH_Calibration` in the `Modules` menu near the top.
 3. In the `Processing` menu, click `Calibrate DH PSF`.
 4. Save the resulting calibration as a `.dh_json` file. The calibration plots will be automatically saved in the same directory as a png.
+
+#### Cubic spline fitting
+
+1. Open your bead stack in PYMEImage. 
+2. Load the double-helix calibration module by clicking on `DH_Calibration` in the `Modules` menu near the top.
+3. Click the center of a bead image and click `Tag Bead` in the lower left `DH PSF Extraction` panel. If you adjust the ROI half size, press `Clear` and re-tag the bead. Similarly if you prefer to align the beads
+on a slice other than the center of the Z-stack, adjust `Center slice` and re-tag.
+4. After selecting the beads you would like to average, click `Extract PSF`.
+5. If the extracted PSF stack is satisfactory, save it to `.h5` or `.tif`.
 
 ### Filter Optimization
 The detection filter has a width scaling parameter, filter sigma, which you will want to have tuned to your PSF.
@@ -68,13 +80,17 @@ PYME can facilitate distributed batch analysis of many series, but we will descr
 1. Start the `PYMEClusterOfOne`.
 2. Open your image series in `PYMEImage`
 3. If your image is not an `.h5` file type, you will likely need to activate the `LMAnalysis` module
+4. In the `Type` dropdown of the `Analysis` panel on the left, select `double_helix.DoubleGaussFit` or `double_helix.SplineFit`.
 4. Select your prefered background subtraction. We recommend checking `Use percentile for background`.
 5. If you have variance, dark, or flat maps to load, do so. Otherwise, scalar values will be used as listed in the metadata.
-6. Enter your double helix deteciton settings, as informed by your PSF calibration. The expected lobe separation [nm], and expected lobe sigma [nm] are starting points for each fit, and should be set using reasonable ~middle values from your PSF calibration.
+6. Enter your double helix detection settings, as informed by your PSF calibration. The expected lobe separation [nm], and expected lobe sigma [nm] should be set using reasonable ~middle values from your PSF calibration.
+7. if using `double_helix.SplineFit`, use the `Set` button next to `PSF: ` to load your extracted PSF `.h5` or `.tif`.
 7. Enter a value for the detection filter sigma as optimized above.
 8. Click `Test This Frame` and see how well molecules are detected and fitted. Adjust the `Thresh` value, and any other settings as necessary.
 
 ### Z-lookup for fitted localizations
+
+Z lookup is built-into `double_helix.SplineFit`, but for `DoubleGaussFit` the fitted orientation must be mapped to the calibrated Z position:
 
 1. Open a set of localized points in `PYMEVis`.
 2. In the `Corrections` menu, click `Double Helix > Map and Filter on DH parameters`.

--- a/double_helix/SplineFit.py
+++ b/double_helix/SplineFit.py
@@ -50,6 +50,7 @@ class ZEstimator(object):
         n_z = len(z_vals)
         z = np.empty(n_z)
         angle = np.empty(n_z)
+        peak = np.empty(n_z)  # PSF peak at unit amplitude for each z slice
         # need to instantiate a detector to pull the orientation estimate. Assume the brightest strength is at the center and extract
         # that angle
         calibration_detector = Detector(metadata.getEntry('Analysis.ROISize'),
@@ -65,16 +66,26 @@ class ZEstimator(object):
             strength_image, angle_image = calibration_detector.filter_frame(slice_data.T)  # keep the transpose to match with FindAndFit
             row, col = np.where(strength_image == strength_image.max())
             angle[z_ind] = angle_image[row[0], col[0]]
+            peak[z_ind] = slice_data.max()  # PSF peak at A=1; interpolator is normalized by sum of in-focus plane
         
         # spline z as a function of angle 
         spline = UnivariateSpline(angle, z)
         self.splines['z'] = spline
+        # spline PSF peak (at A=1) as a function of z, for amplitude initial-guess scaling
+        self.splines['peak'] = UnivariateSpline(z_vals, peak)
     
     def estimate_z_from_orientation(self, orientation):
         if not 'z' in self.splines.keys():
             raise ValueError('Z estimator not calibrated')
         
         return self.splines['z'](orientation)
+    
+    def estimate_amplitude(self, data_range, z):
+        """Scale data_range by the calibrated PSF peak at the given z (nm)."""
+        if 'peak' not in self.splines:
+            raise ValueError('Z estimator not calibrated')
+        psf_peak = float(self.splines['peak'](z))
+        return data_range / psf_peak if psf_peak > 1e-6 else data_range
 
 
 class PSFFitFactory(FFBase.FFBase):
@@ -160,7 +171,6 @@ class PSFFitFactory(FFBase.FFBase):
         # _dh_detector.normFactor * (threshold * self.noiseSigma.squeeze())**2 allows for thresholding on
         #   values similar to SNR
         row, col, orientation = _dh_detector.extract_candidates(strength_image, angle_image, _dh_detector.normFactor * (threshold * self.noiseSigma.T.squeeze())**2)
-
         # lobe_sep_pix = self.metadata.getEntry('Analysis.LobeSepGuess') / self.metadata.voxelsize_nm.x
         # x0, y0, x1, y1 = lobe_estimate_from_center_pixel(col, row, orientation, lobe_sep_pix)
         # convert positions from pixels to nm
@@ -187,15 +197,19 @@ class PSFFitFactory(FFBase.FFBase):
             X, Y, data, background, sigma, xslice, yslice, zslice = self.getROIAtPoint(x_pix, y_pix, None, roi_half_size)
             X, Y, Z, safeRegion = self.interpolator.getCoords(self.metadata, xslice, yslice, zslice)
             dataMean = data - background
-            
-            amp = (data - data.min()).max() #amplitude
 
-            # vs = self.metadata.voxelsize_nm
-            # x0 =  vs.x*x
-            # y0 =  vs.y*y
-            
             bgm = np.mean(background)
-            guess = (amp, x_nm[ind], y_nm[ind], z_nm[ind], dataMean.min())
+            # x0/y0 guess must be in getCoords coordinates (pixel-index nm, no roi_offset),
+            # not absolute image nm. Use the center of the X/Y grid.
+            x0_guess = X[len(X)//2]
+            y0_guess = Y[len(Y)//2]
+            # Negate z: f_Interp3d samples PSF at Z-z0; ZEstimator returns raw IntZVals.
+            z0_guess = -float(z_nm[ind])
+
+            data_range = float((dataMean - dataMean.min()).max())
+            amp = self.startPosEstimator.estimate_amplitude(data_range, float(z_nm[ind]))
+
+            guess = (amp, x0_guess, y0_guess, z0_guess, float(dataMean.min()))
             
             #do the fit
             # (res, cov_x, infodict, mesg, resCode) = self.solver(self.fitfcn, guess, data, sigma, X, Y, background)
@@ -213,29 +227,13 @@ class PSFFitFactory(FFBase.FFBase):
             nchi2 = (infodict['fvec']**2).sum()/(dataMean.size - res.size)
             
             if False:
-                #display for debugging purposes
+                from PYME.localization.FitFactories.InterpFitR import f_Interp3d
                 import matplotlib.pyplot as plt
-                plt.figure(figsize=(20, 5))
-                plt.subplot(151)
-                plt.title('Background')
-                plt.imshow(background)
-                plt.colorbar()
-                plt.subplot(152)
-                plt.title('Background Sub')
-                plt.imshow(dataMean)
-                plt.colorbar()
-                plt.subplot(153)
-                plt.title('Init. Guess')
-                plt.imshow(f_dh(guess, X, Y))
-                plt.colorbar()
-                plt.subplot(154)
-                plt.title('Fitted Results')
-                plt.imshow(f_dh(res, X, Y))
-                plt.colorbar()
-                plt.subplot(155)
-                plt.title('Residuals')
-                plt.imshow(dataMean-f_dh(res, X, Y))
-                plt.colorbar()
+                model_at_guess = f_Interp3d(guess, self.interpolator, X, Y, Z, safeRegion)
+                plt.figure(figsize=(10, 4))
+                plt.subplot(121); plt.title(f'dataMean (candidate {ind})'); plt.imshow(dataMean.squeeze().T); plt.colorbar()
+                plt.subplot(122); plt.title(f'PSF at guess z0={guess[3]:.1f}nm'); plt.imshow(model_at_guess.squeeze().T); plt.colorbar()
+                plt.show()
 
             #package results
             results[ind] = pack_results(FitResultsDType, self.metadata.tIndex, res, fit_errors, startParams=guess, slicesUsed=(xslice, yslice, zslice), 

--- a/double_helix/SplineFit.py
+++ b/double_helix/SplineFit.py
@@ -251,7 +251,7 @@ import PYME.localization.MetaDataEdit as mde
 
 PARAMETERS = [
     mde.IntParam('Analysis.ROISize', u'ROI half size', 10),
-    mde.FilenameParam('PSFFile', 'PSF:', prompt='Please select PSF to use ...', wildcard='PSF Files|*.psf|TIFF files|*.tif|H5 files|*.h5'),
+    mde.FilenameParam('PSFFile', 'PSF:', prompt='Please select PSF to use ...', wildcard='PSF Files|*.psf;*.tif;*.h5'),
     mde.FloatParam('Analysis.DetectionFilterSigma', 'Detection Filter Sigma (in px):', 8.0,
                  'scales filters spatially'),
     mde.FloatParam('Analysis.LobeSepGuess', 'Double Helix Lobe Separation Guess [nm]:', 900,

--- a/double_helix/SplineFit.py
+++ b/double_helix/SplineFit.py
@@ -1,0 +1,267 @@
+#!/usr/bin/python
+
+##################
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##################
+
+import numpy as np
+from PYME.localization.FitFactories.fitCommon import fmtSlicesUsed, pack_results
+from PYME.localization.FitFactories import FFBase 
+from PYME.Analysis._fithelpers import FitModelWeighted_, FitModelWeightedJac
+
+from double_helix.DoubleGaussFit import Detector
+from PYME.localization.FitFactories import InterpFitR
+from PYME.localization.FitFactories.Interpolators import CSInterpolator
+import logging
+logger = logging.getLogger(__name__)
+
+_dh_detector = None
+_start_pos_estimator = None
+
+
+class ZEstimator(object):
+    def __init__(self):
+        self.splines = {}
+    
+    def calibrate(self, interpolator, metadata):
+        from scipy.interpolate import UnivariateSpline
+        # generate grid for evaluation
+        roi_size = metadata.getEntry('Analysis.ROISize')
+        X, Y, Z, safe_region = interpolator.getCoords(metadata, 
+                                                      slice(-roi_size, roi_size), 
+                                                      slice(-roi_size, roi_size), 
+                                                      slice(0, 2))
+        # get Z range from interpolator model extent, excluding boundary slices
+        # that cInterp cannot evaluate (cubic spline requires ~3 index margin)
+        z_vals = interpolator.IntZVals[3:-3]
+        n_z = len(z_vals)
+        z = np.empty(n_z)
+        angle = np.empty(n_z)
+        # need to instantiate a detector to pull the orientation estimate. Assume the brightest strength is at the center and extract
+        # that angle
+        calibration_detector = Detector(metadata.getEntry('Analysis.ROISize'),
+                                        l_initial=metadata.getEntry('Analysis.LobeSepGuess'),
+                                        lobe_sigma_initial=metadata.getEntry('Analysis.SigmaGuess'),
+                                        filter_sigma=metadata.getEntry('Analysis.DetectionFilterSigma'),
+                                        px_size_nm=metadata.voxelsize_nm.x)
+        
+        # # evaluate PSF on grid
+        for z_ind, z_val in enumerate(z_vals):
+            z[z_ind] = z_val
+            slice_data = interpolator.interp(X, Y, Z + z_val).squeeze()
+            strength_image, angle_image = calibration_detector.filter_frame(slice_data.T)  # keep the transpose to match with FindAndFit
+            row, col = np.where(strength_image == strength_image.max())
+            angle[z_ind] = angle_image[row[0], col[0]]
+        
+        # spline z as a function of angle 
+        spline = UnivariateSpline(angle, z)
+        self.splines['z'] = spline
+    
+    def estimate_z_from_orientation(self, orientation):
+        if not 'z' in self.splines.keys():
+            raise ValueError('Z estimator not calibrated')
+        
+        return self.splines['z'](orientation)
+
+
+class PSFFitFactory(FFBase.FFBase):
+    def __init__(self, data, metadata, fitfcn=InterpFitR.f_Interp3d, background=None, noiseSigma=None, **kwargs):
+        super(PSFFitFactory, self).__init__(data, metadata, fitfcn, background, noiseSigma, **kwargs)
+        
+        if 'D' in dir(fitfcn):
+            self.solver = FitModelWeightedJac
+        else:
+            self.solver = FitModelWeighted_
+        
+        # interp_module = metadata.getOrDefault('Analysis.InterpModule', 'CSInterpolator')
+        self.interpolator = CSInterpolator.interpolator
+
+        global _start_pos_estimator
+        if _start_pos_estimator is None:
+            _start_pos_estimator = ZEstimator()
+        self.startPosEstimator = _start_pos_estimator
+
+        if self.interpolator.setModelFromMetadata(metadata):
+            logger.info('model changed')
+            self.startPosEstimator.splines.clear()
+
+        if not 'z' in self.startPosEstimator.splines.keys():
+            # we need to get a "z" vs theta spline 
+            self.startPosEstimator.calibrate(self.interpolator, metadata)
+            
+    
+    def estimate_z_from_orientation(self, orientation):
+        return self.startPosEstimator.estimate_z_from_orientation(orientation)
+
+    def refresh_detector(self):
+
+        global _dh_detector # One instance for each process, re-used for subsequent fits.
+
+        # make one at the end, otherwise if we're OK return early
+        need_fresh = False
+        if not _dh_detector:
+            need_fresh = True  # we don't have one yet
+        else:
+            need_fresh = _dh_detector.roi_half_size != self.metadata.getEntry('Analysis.ROISize') or _dh_detector.filter_sigma != self.metadata.getEntry('Analysis.DetectionFilterSigma')
+        
+        if need_fresh:
+            _dh_detector = Detector(self.metadata.getEntry('Analysis.ROISize'),
+                                    l_initial=self.metadata.getEntry('Analysis.LobeSepGuess'),
+                                    lobe_sigma_initial=self.metadata.getEntry('Analysis.SigmaGuess'),
+                                    filter_sigma=self.metadata.getEntry('Analysis.DetectionFilterSigma'),
+                                    px_size_nm=self.metadata.voxelsize_nm.x)
+        return
+    
+    def FindAndFit(self, threshold, cameraMaps, **kwargs):
+        """
+
+        Parameters
+        ----------
+        threshold: float
+            detection threshold, as a multiple of per-pixel noise standard deviation
+        cameraMaps: cameraInfoManager object (see remFitBuf.py)
+
+        Returns
+        -------
+        results
+
+        """
+        # make sure we've built correct filters
+        self.refresh_detector()
+
+        # at this point, data is in ADU, with offset subtracted and flatfield applied
+        
+        # Find candidate molecule positions on background-subtracted frame
+        if self.background is not None:
+            bgd = (self.data.astype('f') - self.background).squeeze()
+        else:
+            bgd = self.data.astype('f').squeeze()
+        # print(bgd.shape)
+
+        # negative values in bg subtraction lead to detection artefacts so make any negative pixel have value of 0
+        bgd[bgd<0] = 0
+        
+        # Note PYME flips row/col y/x, so feed the detector a Transposed frame to get it 'right'
+        strength_image, angle_image = _dh_detector.filter_frame(bgd.T)
+
+        # _dh_detector.normFactor * (threshold * self.noiseSigma.squeeze())**2 allows for thresholding on
+        #   values similar to SNR
+        row, col, orientation = _dh_detector.extract_candidates(strength_image, angle_image, _dh_detector.normFactor * (threshold * self.noiseSigma.T.squeeze())**2)
+
+        # lobe_sep_pix = self.metadata.getEntry('Analysis.LobeSepGuess') / self.metadata.voxelsize_nm.x
+        # x0, y0, x1, y1 = lobe_estimate_from_center_pixel(col, row, orientation, lobe_sep_pix)
+        # convert positions from pixels to nm
+        x_nm = self.metadata.voxelsize_nm.x * (col + self.roi_offset[0])
+        y_nm = self.metadata.voxelsize_nm.y * (row + self.roi_offset[1])
+        # x0_nm = self.metadata.voxelsize_nm.x * (x0 + self.roi_offset[0])
+        # x1_nm = self.metadata.voxelsize_nm.x * (x1 + self.roi_offset[0])
+        # y0_nm = self.metadata.voxelsize_nm.y * (y0 + self.roi_offset[1])
+        # y1_nm = self.metadata.voxelsize_nm.y * (y1 + self.roi_offset[1])
+        
+        z_nm = self.estimate_z_from_orientation(orientation)
+
+        #PYME ROISize is a half size
+        roi_half_size = self.metadata.getEntry('Analysis.ROISize')  # int(2*self.metadata.getEntry('Analysis.ROISize') + 1)
+        lobe_sep = self.metadata.getEntry('Analysis.LobeSepGuess')  # [nm]
+        sigma_guess = self.metadata.getEntry('Analysis.SigmaGuess')  # [nm]
+        ########## Actually do the fits #############
+        n_cand = len(row)
+        results = np.empty(n_cand, FitResultsDType)
+
+        for ind in range(n_cand):
+            x_pix = col[ind]
+            y_pix = row[ind]
+            X, Y, data, background, sigma, xslice, yslice, zslice = self.getROIAtPoint(x_pix, y_pix, None, roi_half_size)
+            X, Y, Z, safeRegion = self.interpolator.getCoords(self.metadata, xslice, yslice, zslice)
+            dataMean = data - background
+            
+            amp = (data - data.min()).max() #amplitude
+
+            # vs = self.metadata.voxelsize_nm
+            # x0 =  vs.x*x
+            # y0 =  vs.y*y
+            
+            bgm = np.mean(background)
+            guess = (amp, x_nm[ind], y_nm[ind], z_nm[ind], dataMean.min())
+            
+            #do the fit
+            # (res, cov_x, infodict, mesg, resCode) = self.solver(self.fitfcn, guess, data, sigma, X, Y, background)
+            (res, cov_x, infodict, mesg, resCode) = self.solver(self.fitfcn, guess, dataMean, sigma, self.interpolator, X, Y, Z, safeRegion)
+
+
+            #try to estimate errors based on the covariance matrix
+            fit_errors=None
+            try:       
+                fit_errors = np.sqrt(np.diag(cov_x)*(infodict['fvec']*infodict['fvec']).sum()/(len(dataMean.ravel())- len(res)))
+            except Exception:
+                pass
+            
+            #normalised Chi-squared
+            nchi2 = (infodict['fvec']**2).sum()/(dataMean.size - res.size)
+            
+            if False:
+                #display for debugging purposes
+                import matplotlib.pyplot as plt
+                plt.figure(figsize=(20, 5))
+                plt.subplot(151)
+                plt.title('Background')
+                plt.imshow(background)
+                plt.colorbar()
+                plt.subplot(152)
+                plt.title('Background Sub')
+                plt.imshow(dataMean)
+                plt.colorbar()
+                plt.subplot(153)
+                plt.title('Init. Guess')
+                plt.imshow(f_dh(guess, X, Y))
+                plt.colorbar()
+                plt.subplot(154)
+                plt.title('Fitted Results')
+                plt.imshow(f_dh(res, X, Y))
+                plt.colorbar()
+                plt.subplot(155)
+                plt.title('Residuals')
+                plt.imshow(dataMean-f_dh(res, X, Y))
+                plt.colorbar()
+
+            #package results
+            results[ind] = pack_results(FitResultsDType, self.metadata.tIndex, res, fit_errors, startParams=guess, slicesUsed=(xslice, yslice, zslice), 
+                                resultCode=resCode, subtractedBackground=bgm, nchi2=nchi2)  # , length=length, x=x_com, y=y_com, theta=theta)
+        
+        return results
+
+FitFactory = PSFFitFactory
+FitResult = InterpFitR.FitResult
+FitResultsDType = InterpFitR.FitResultsDType
+
+MULTIFIT=True # flag that this module does its own detection
+
+import PYME.localization.MetaDataEdit as mde
+
+PARAMETERS = [
+    mde.IntParam('Analysis.ROISize', u'ROI half size', 10),
+    mde.FilenameParam('PSFFile', 'PSF:', prompt='Please select PSF to use ...', wildcard='PSF Files|*.psf|TIFF files|*.tif|H5 files|*.h5'),
+    mde.FloatParam('Analysis.DetectionFilterSigma', 'Detection Filter Sigma (in px):', 8.0,
+                 'scales filters spatially'),
+    mde.FloatParam('Analysis.LobeSepGuess', 'Double Helix Lobe Separation Guess [nm]:', 900,
+                   'What lobe separation should the detector use for intensity normalization?'),
+    mde.FloatParam('Analysis.SigmaGuess', 'Double Helix Lobe Sigma Guess [nm]:', 180,
+                   'Estimate for Gaussian sigma parameter to use for intensity normalization during detection')
+]
+
+DESCRIPTION = '3D, double helix fitting using an interpolated PSF.'
+LONG_DESCRIPTION = DESCRIPTION
+USE_FOR = '3D using a Double-Helix point-spread function'

--- a/double_helix/double_helix.yaml
+++ b/double_helix/double_helix.yaml
@@ -15,3 +15,4 @@ fit_factories:
     # - double_helix.FitFactories.DoubleHelixFit_Theta
     # - double_helix.FitFactories.DoubleHelixFit_SepGuess
     - double_helix.DoubleGaussFit
+    - double_helix.SplineFit

--- a/double_helix/image_modules/DH_calibration.py
+++ b/double_helix/image_modules/DH_calibration.py
@@ -5,26 +5,278 @@ import wx
 import logging
 logger = logging.getLogger(__name__)
 
+
+def _xy_centroid(im_2d):
+    """
+    Thresholded intensity-weighted centroid of a 2D array.
+
+    Returns (dx, dy) offsets from the array centre, matching the threshold
+    logic used by PYME.Analysis.PSFEst.extractImages.getIntCenter.
+    """
+    import numpy as np
+    im = np.asarray(im_2d, dtype='f').squeeze()
+    im2 = im - im.min()
+    im2 = im2 - 0.5 * im2.max()
+    im2 = np.maximum(im2, 0)
+    total = im2.sum()
+    if total < 1e-9:
+        return 0.0, 0.0
+    nx, ny = im2.shape
+    X = np.arange(nx, dtype='f') - (nx - 1) / 2.0
+    Y = np.arange(ny, dtype='f') - (ny - 1) / 2.0
+    dx = float((im2 * X[:, None]).sum() / total)
+    dy = float((im2 * Y[None, :]).sum() / total)
+    return dx, dy
+
+
+def _extract_dh_psf(data_3d, locs, center_slice, roi_half_xy, blur):
+    """
+    Extract a DH PSF by averaging XY-centered sub-stacks from multiple bead locations.
+
+    For each tagged bead a full-z ROI is extracted.  The XY centroid is estimated
+    on z= `center_slice`, and the beads sub-stacks are laterally aligned with
+    sub-pixel precision by applying a phase ramp to each sub-stack in Fourier space
+    before averaging.
+
+    While the beads are centered on `center_slice`, any z-dependent XY wobble
+    should remain in the extracted PSF.
+
+    Parameters
+    ----------
+    data_3d : ndarray, shape (nx, ny, nz)
+    locs : list of (xp, yp) - pixel positions of tagged beads (may be float)
+    center_slice : int
+        Z-slice index used for lateral centroid estimation.
+    roi_half_xy : int
+        Half-size of the output ROI in x and y (pixels).
+    blur : sequence of 3 floats
+        Gaussian sigma in (x, y, z) applied after averaging.
+
+    Returns
+    -------
+    psf : ndarray, shape (2*roi_half_xy+1, 2*roi_half_xy+1, nz), max-normalised
+    """
+    import numpy as np
+    import scipy.ndimage
+
+    data_3d = data_3d.astype('f')
+    n_x, n_y, n_z = data_3d.shape
+    rs = roi_half_xy
+    height = width = 2 * rs + 1
+
+    # Fourier frequency grids for the ROI
+    kx = np.fft.fftshift(np.arange(height) - rs) / height
+    ky = np.fft.fftshift(np.arange(width) - rs) / width
+    KX, KY = np.meshgrid(kx, ky, indexing='ij')
+
+    psf_sum = np.zeros((height, width, n_z), dtype='f')
+
+    for xp, yp in locs:
+        xp_int = int(round(xp))
+        yp_int = int(round(yp))
+
+        # ROI is guaranteed in-bounds - no padding needed
+        x0, x1 = xp_int - rs, xp_int + rs + 1
+        y0, y1 = yp_int - rs, yp_int + rs + 1
+        roi = data_3d[x0:x1, y0:y1, :].copy()
+
+        # XY centroid from center slice only
+        dx, dy = _xy_centroid(roi[:, :, center_slice])
+
+        # Single phase ramp applied to the whole stack – preserves z-wobble
+        phase = np.exp(-2j * np.pi * (KX * (-dx) + KY * (-dy)))
+        for z_idx in range(n_z):
+            psf_sum[:, :, z_idx] += np.fft.ifft2(
+                np.fft.fft2(roi[:, :, z_idx]) * phase).real
+
+    psf = psf_sum / len(locs)
+    psf = scipy.ndimage.gaussian_filter(psf, blur)
+    psf -= psf.min()
+    if psf.max() > 1e-6:
+        psf /= psf.max()
+    return psf
+
+
 class DHCalibrator(Plugin):
     def __init__(self, dsviewer):
         Plugin.__init__(self, dsviewer)
-        # #generate new tab to show results
-        # self.use_web_view = True
-        # if not '_dh_view' in dir(self):
-        #     try:
-        #         self._dh_view= wx.html2.WebView.New(self.dsviewer)
-        #         self.dsviewer.AddPage(self._dh_view, True, 'Double-Helix Cal.')
-
-        #     except (NotImplementedError, AttributeError):
         self.use_web_view = False
 
         self._calibrations = []
         self._optimizations = []
-        
+
+        # State for PSF extraction panel
+        self._psf_locs = []           # list of (xp, yp) tagged bead positions
+        self._psf_roi_half_xy = 30    # kept in sync with the panel text control
+
+        dsviewer.paneHooks.append(self.GenDHPSFPanel)
+        dsviewer.view.add_overlay(self.DrawOverlays, 'DH PSF ROIs')
+
         logging.debug('Adding menu items for double-helix PSF calibration')
-        dsviewer.AddMenuItem('Processing', 'Calibrate DH PSF', self.OnCalibrate)        
+        dsviewer.AddMenuItem('Processing', 'Calibrate DH PSF', self.OnCalibrate)
         dsviewer.AddMenuItem('Processing', 'Optimize DH PSF Detection', self.OnOptimizeDetection)
         dsviewer.AddMenuItem('Processing', 'Test DH PSF Detection', self.OnTestDetection)
+    
+
+    def GenDHPSFPanel(self, _pnl):
+        import PYME.ui.manualFoldPanel as afp
+
+        item = afp.foldingPane(_pnl, -1, caption='DH PSF Extraction', pinned=True)
+        pan = wx.Panel(item, -1)
+        vsizer = wx.BoxSizer(wx.VERTICAL)
+
+        # Tag / Clear row
+        hsizer = wx.BoxSizer(wx.HORIZONTAL)
+        bTag = wx.Button(pan, -1, 'Tag Bead', style=wx.BU_EXACTFIT)
+        bTag.Bind(wx.EVT_BUTTON, self.OnTagBead)
+        hsizer.Add(bTag, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
+        bClear = wx.Button(pan, -1, 'Clear', style=wx.BU_EXACTFIT)
+        bClear.Bind(wx.EVT_BUTTON, self.OnClearBeads)
+        hsizer.Add(bClear, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
+        vsizer.Add(hsizer, 0, wx.ALL, 0)
+
+        # ROI half size
+        hsizer = wx.BoxSizer(wx.HORIZONTAL)
+        hsizer.Add(wx.StaticText(pan, -1, 'ROI half size [px]:'), 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
+        self.tDHPSFROI = wx.TextCtrl(pan, -1, value='30', size=(50, -1))
+        self.tDHPSFROI.Bind(wx.EVT_TEXT, self.OnDHROIChanged)
+        hsizer.Add(self.tDHPSFROI, 1, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
+        vsizer.Add(hsizer, 0, wx.EXPAND | wx.ALL, 0)
+
+        # Center slice
+        n_z = self.dsviewer.image.data_xyztc.shape[2]
+        hsizer = wx.BoxSizer(wx.HORIZONTAL)
+        hsizer.Add(wx.StaticText(pan, -1, 'Center slice:'), 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
+        self.tDHCenterSlice = wx.SpinCtrl(pan, -1, value=str(n_z // 2),
+                                          min=0, max=max(0, n_z - 1), size=(60, -1))
+        hsizer.Add(self.tDHCenterSlice, 1, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
+        vsizer.Add(hsizer, 0, wx.EXPAND | wx.ALL, 0)
+
+        # Blur
+        hsizer = wx.BoxSizer(wx.HORIZONTAL)
+        hsizer.Add(wx.StaticText(pan, -1, u'Blur \u03c3 (x,y,z):'), 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
+        self.tDHPSFBlur = wx.TextCtrl(pan, -1, value='0.5,0.5,1.0', size=(80, -1))
+        hsizer.Add(self.tDHPSFBlur, 1, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
+        vsizer.Add(hsizer, 0, wx.EXPAND | wx.ALL, 0)
+
+        # Extract button
+        bExtract = wx.Button(pan, -1, 'Extract PSF', style=wx.BU_EXACTFIT)
+        bExtract.Bind(wx.EVT_BUTTON, self.OnExtractDHPSF)
+        vsizer.Add(bExtract, 0, wx.ALL | wx.ALIGN_RIGHT, 5)
+
+        pan.SetSizer(vsizer)
+        vsizer.Fit(pan)
+        item.AddNewElement(pan)
+        _pnl.AddPane(item)
+
+    def OnTagBead(self, event):
+        """Tag the bead nearest the cursor, or un-tag it if already tagged.
+
+        Tags are rejected if the ROI would extend beyond the image boundary.
+        """
+        import numpy as np
+
+        xp = self.dsviewer.do.xp
+        yp = self.dsviewer.do.yp
+        rs = self._psf_roi_half_xy
+
+        # Un-tag if clicking within the ROI of an existing tag
+        for i, (tx, ty) in enumerate(self._psf_locs):
+            if (xp - tx) ** 2 + (yp - ty) ** 2 < rs ** 2:
+                self._psf_locs.pop(i)
+                self.dsviewer.view.Refresh()
+                return
+
+        # Reject if the ROI would extend beyond the image boundary
+        image = self.dsviewer.image
+        n_x, n_y = image.data_xyztc.shape[:2]
+        xp_int, yp_int = int(round(xp)), int(round(yp))
+        if (xp_int - rs < 0 or xp_int + rs + 1 > n_x or
+                yp_int - rs < 0 or yp_int + rs + 1 > n_y):
+            wx.MessageBox(
+                f'Bead too close to the image edge for ROI half-size {rs} px.',
+                'Tag Bead', wx.OK | wx.ICON_WARNING)
+            return
+
+        # Refine position: intensity-weighted centroid in center slice
+        center_slice = self.tDHCenterSlice.GetValue()
+        x0, x1 = xp_int - rs, xp_int + rs + 1
+        y0, y1 = yp_int - rs, yp_int + rs + 1
+        roi_2d = np.array(image.data_xyztc[x0:x1, y0:y1, center_slice, 0, 0]).squeeze()
+        dx, dy = _xy_centroid(roi_2d)
+
+        # dx/dy are offsets from the ROI centre; convert to image coordinates
+        roi_cx = (x0 + x1 - 1) / 2.0
+        roi_cy = (y0 + y1 - 1) / 2.0
+        self._psf_locs.append((roi_cx + dx, roi_cy + dy))
+        self.dsviewer.view.Refresh()
+
+    def OnClearBeads(self, event):
+        self._psf_locs.clear()
+        self.dsviewer.view.Refresh()
+
+    def OnDHROIChanged(self, event):
+        try:
+            self._psf_roi_half_xy = int(self.tDHPSFROI.GetValue())
+        except ValueError:
+            pass
+
+    def DrawOverlays(self, view, dc):
+        """Draw green ROI boxes around tagged bead positions (XY view only)."""
+        if not self._psf_locs:
+            return
+        rs = self._psf_roi_half_xy
+        dc.SetBrush(wx.TRANSPARENT_BRUSH)
+        dc.SetPen(wx.Pen(wx.TheColourDatabase.FindColour('GREEN'), 1))
+        if view.do.slice == view.do.SLICE_XY:
+            for xp, yp in self._psf_locs:
+                xp0, yp0 = view.pixel_to_screen_coordinates(xp - rs, yp - rs)
+                xp1, yp1 = view.pixel_to_screen_coordinates(xp + rs, yp + rs)
+                dc.DrawRectangle(int(xp0), int(yp0), int(xp1 - xp0), int(yp1 - yp0))
+
+    def OnExtractDHPSF(self, wx_event=None):
+        """Average XY-centered sub-stacks from all tagged bead positions."""
+        import numpy as np
+        from PYME.DSView.dsviewer import ImageStack, ViewIm3D
+        from PYME.IO.MetaDataHandler import NestedClassMDHandler
+
+        if not self._psf_locs:
+            wx.MessageBox('No beads tagged.  Use "Tag Bead" first.',
+                          'DH PSF Extraction', wx.OK | wx.ICON_WARNING)
+            return
+
+        try:
+            roi_half_xy = int(self.tDHPSFROI.GetValue())
+            blur = [float(s) for s in self.tDHPSFBlur.GetValue().split(',')]
+        except ValueError as exc:
+            wx.MessageBox(f'Invalid parameter: {exc}',
+                          'DH PSF Extraction', wx.OK | wx.ICON_ERROR)
+            return
+
+        center_slice = self.tDHCenterSlice.GetValue()
+        image = self.dsviewer.image
+        n_z = image.data_xyztc.shape[2]
+        n_c = image.data_xyztc.shape[4]
+
+        psfs = []
+        for chan in range(n_c):
+            data = np.array(image.data_xyztc[:, :, :, 0, chan]).squeeze()
+            psfs.append(_extract_dh_psf(data, self._psf_locs, center_slice, roi_half_xy, blur))
+
+        psf_data = psfs[0] if n_c == 1 else psfs
+
+        mdh = NestedClassMDHandler(image.mdh)
+        mdh['ImageType'] = 'PSF'
+        mdh['PSFExtraction.Mode'] = 'DH-XYonly'
+        mdh['PSFExtraction.ROI'] = [roi_half_xy, roi_half_xy, n_z]
+        mdh['PSFExtraction.Blur'] = blur
+        mdh['PSFExtraction.CenterSlice'] = center_slice  # should remove this, use .Locations
+        mdh['PSFExtraction.Locations'] = self._psf_locs
+
+        im = ImageStack(data=psf_data, mdh=mdh, titleStub='Extracted DH PSF')
+        im.defaultExt = '*.h5'
+        ViewIm3D(im, mode='psf', parent=wx.GetTopLevelParent(self.dsviewer))
+    
 
     def OnCalibrate(self, wx_event=None):
         from PYME.IO.FileUtils import nameUtils


### PR DESCRIPTION
- add `SplineFit` `FitFactory` which uses the steerable DH detection on each frame, then uses `PYME.localization.FitFactories import InterpFitR` to perform an interpolated fit using a cubic spline model (c accelerated interpolation).
- add a PSF extraction panel to the DH_Calibration module in PYMEImage. This mimics PYME's subpixel shift + bead averaging and blurring to extract a PSF. Unlike PYME, this ignores Z shifts and will return a stack the same shape as the input, so users should crop Z in their bead stacks before calling this function. 
- 
- Note that currently, bead alignment during extraction is based on the centroid. While we are at it, coding DH specific PSF extraction, we should consider shifting this to use the double gauss fit instead.